### PR TITLE
fix: Slack notification message not sent (feat. `setup-slack-payload` action)

### DIFF
--- a/.github/actions/setup-slack-payload/action.yml
+++ b/.github/actions/setup-slack-payload/action.yml
@@ -30,7 +30,7 @@ inputs:
 outputs:
   file-path:
     description: The path to the payload file
-    value: ${{ steps.payload.outputs.FILE_PATH }}
+    value: ${{ steps.payload.outputs.file-path }}
 
 runs:
   using: 'composite'


### PR DESCRIPTION
## 🔍 개요

> GitHub Actions `Release` 워크플로우 [#5](https://github.com/herokwon/hero-ds/actions/runs/14962325813) 실행 완료 후 Slack 알림 메시지 미송신 현상 수정

<br />

## 🛠 변경 사항

- `setup-slack-payload` action 출력 변수 값 표기 수정

<br />

## ❗ 관련 이슈

- #12 

<br />

## 💬 참고 사항 (스크린샷, URL, …)

> 이미지 클릭 후 바로가기 🔽

[![image](https://github.com/user-attachments/assets/67f8adea-b6b4-4f59-a4d3-6113b493c292)](https://github.com/herokwon/hero-ds/actions/runs/14962325813)